### PR TITLE
Add support for fmt10 (hg_return_t format)

### DIFF
--- a/include/hermes/logging.hpp
+++ b/include/hermes/logging.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <stdarg.h>
 
+inline auto format_as(hg_return_t f) { return fmt::underlying(f); }
+
 namespace hermes {
 
 namespace detail {


### PR DESCRIPTION
Adds support for fmt10 in Hermes. Successfully tested in GekkoFS.